### PR TITLE
Enable support for qualDirs option in AndroidFenumChecker

### DIFF
--- a/src/sparta/checkers/permission/AndroidFenumChecker.java
+++ b/src/sparta/checkers/permission/AndroidFenumChecker.java
@@ -6,7 +6,7 @@ import org.checkerframework.framework.qual.TypeQualifiers;
 import javax.annotation.processing.SupportedOptions;
 
 import sparta.checkers.permission.qual.Permission;
-@SupportedOptions( { "quals" } )
+@SupportedOptions( { "quals" , "qualDirs" } )
 @TypeQualifiers({ Permission.class })
 public class AndroidFenumChecker extends FenumChecker {
 }


### PR DESCRIPTION
This support is needed to work with the annotation class loader feature in the Checker Framework.
